### PR TITLE
Add commandline option to restrict interface to listen to

### DIFF
--- a/src/manos.exe/Driver.cs
+++ b/src/manos.exe/Driver.cs
@@ -149,11 +149,13 @@ namespace Manos.Tool
 			string port = null;
 			string user = null;
 			string assembly = null;
+			string ipaddress = null;
 			
 			var p = new OptionSet () {
 				{ "p|port=", v => port = v },
 				{ "u|user=", v => user = v },
-				{ "a|assembly=", v=> assembly = v}
+				{ "a|assembly=", v=> assembly = v},
+				{ "l|listen=", v => ipaddress = v }
 			};
 			args = p.Parse(args);
 
@@ -175,6 +177,9 @@ namespace Manos.Tool
 
 			if (user != null)
 				cmd.User = user;
+
+			if (ipaddress != null)
+				cmd.IPAddress = ipaddress;
 
 			cmd.Run ();
 		}

--- a/src/manos.exe/ServerCommand.cs
+++ b/src/manos.exe/ServerCommand.cs
@@ -95,6 +95,11 @@ namespace Manos.Tool
 			get;
 			set;
 		}
+
+		public string IPAddress {
+			get;
+			set;
+		}
 		
 		public void Run ()
 		{
@@ -104,6 +109,8 @@ namespace Manos.Tool
 
 			if (User != null)
 				SetServerUser (User);
+			if (IPAddress != null)
+				AppHost.IPAddress = System.Net.IPAddress.Parse (IPAddress);
 
 			AppHost.Port = Port;
 			AppHost.Start (app);


### PR DESCRIPTION
In case we want to be only on localhost when proxying for instance
