### PR TITLE
Prototype implementation of a generic, C#-based configuration engine for Manos

### DIFF
--- a/examples/Shorty/Shorty.cs
+++ b/examples/Shorty/Shorty.cs
@@ -44,7 +44,7 @@ namespace Shorty {
 		public void Index (IManosContext ctx)
 		{
 			ctx.Response.End (@"<html>
-                                   <head><title>Welcome to Shorty</title></head>
+                                   <head><title>" + ManosConfig.Get ("shorty.title") + @"</title></head>
                                    <body>
                                     <form method='POST' action='submit-link'>
                                      <input type='text' name='link' /><br />

--- a/examples/Shorty/manos.config
+++ b/examples/Shorty/manos.config
@@ -1,0 +1,1 @@
+ManosConfig.Add ("shorty.title", "Welcome to Shorty");

--- a/src/Manos/Manos.csproj
+++ b/src/Manos/Manos.csproj
@@ -36,10 +36,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Posix, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Library\Frameworks\Mono.framework\Versions\Current\lib\mono\2.0\Mono.Posix.dll</HintPath>
-    </Reference>
+    <Reference Include="Mono.Posix" />
+    <Reference Include="Mono.CSharp" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Manos\DeleteAttribute.cs" />
@@ -149,6 +147,7 @@
     <Compile Include="Libev\UnmanagedWatcherCallback.cs" />
     <Compile Include="Libev\Watcher.cs" />
     <Compile Include="Manos.Http.Testing\MockHttpResponse.cs" />
+    <Compile Include="Manos\ManosConfig.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Manos/Manos/ManosApp.cs
+++ b/src/Manos/Manos/ManosApp.cs
@@ -42,6 +42,7 @@ namespace Manos {
 		
 		public ManosApp ()
 		{
+			ManosConfig.Load (this);
 		}
 
 		public void HandleTransaction (ManosApp app, IHttpTransaction con)

--- a/src/Manos/Manos/ManosConfig.cs
+++ b/src/Manos/Manos/ManosConfig.cs
@@ -1,0 +1,136 @@
+//
+// Copyright (C) 2010 Jackson Harper (jackson@manosdemono.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Reflection;
+using Mono.CSharp;
+
+namespace Manos
+{
+	public class ManosConfigException : Exception
+	{
+		public ManosConfigException (string msg) 
+		: base (msg)
+		{
+		}
+		
+		public ManosConfigException (string fmt, params object[] args) 
+		: base (String.Format (fmt, args))
+		{
+		}
+	}
+	
+	public static class ManosConfig
+	{
+		// Property storage
+		private static Dictionary<string, object> cfg = new Dictionary<string, object> ();
+		
+		static ManosConfig ()
+		{
+			cfg.Add ("Manos.Version", Assembly.GetExecutingAssembly ().ToString());	
+		}
+				
+#region Public methods
+		
+		// Load configuration from file
+		// Search path:
+		//	1.<app_folder>/manos.config
+		public static void Load (IManosPipe pipe)
+		{
+			string [] sources =
+			{
+				Path.Combine (Environment.CurrentDirectory, "manos.config"),
+			};
+			
+			foreach (string src in sources)
+			{
+				try
+				{
+					if (File.Exists (src))
+						CompileFile (src);
+				}
+				catch (Exception ex)
+				{
+					Console.Error.WriteLine ("** Error processing config file '{0}': {1}", src, ex.Message);
+					Console.Error.WriteLine ("** Trace: {0}", ex.StackTrace);
+					continue; 
+				}
+			}	
+		}
+		
+		public static void Add<T> (string key, T val)
+		{		
+			lock (cfg)
+			{
+				cfg.Remove (key);
+					
+				cfg.Add (key, val);	
+			}
+		}
+		
+		public static void Add (string key, object val)
+		{
+			Add<object> (key, val);
+		}
+		
+		
+		public static T Get<T> (string key)
+		{
+			object tmp;
+			
+			if (cfg.TryGetValue (key, out tmp))
+				return (T)tmp;
+			else
+				return default(T);
+		}
+		
+		public static object Get (string key)
+		{
+			return Get<object> (key);
+		}
+		
+#endregion
+		
+#region Private methods		
+		private static bool CompileFile (string path)
+		{
+			using (StreamReader sr = new StreamReader (path))
+			{
+				string txt = sr.ReadToEnd ();
+				
+				Evaluator.Init (new string[0]);
+				Evaluator.ReferenceAssembly (Assembly.GetExecutingAssembly ());
+				Evaluator.Run ("using Manos;");
+				Evaluator.Run (txt);
+				
+				return true;
+			}
+		}
+		
+#endregion		
+	}	
+}
+


### PR DESCRIPTION
I've put together a simple, basic system prototype to allow loading of configuration files at application startup. I think this feature is important for storing environment-specific stuff, connection strings, user id's and etc. 
The system is not yet complete and does very little, but I'd like to get your feedback on the architecture and see if that's the kind of thing you have in mind.

So, a new static `ManosConfig` class has been added. This class contains the code to parse C# scripts at startup, and the accessor methods to set and get configuration key/value pairs. When calling `ManosConfig.Load()` (I put it in ManosApp.cs because I'm still not too familiar with the core of the app: you'll probably find a better place for it), it will look for a file manos.config in the app's directory and execute it using Mono.CSharp.
The manos.config file should contain statements of the form:
    ManosConfig.Add ("foo", "bar")
or the strongly-typed version 
    ManosConfig.Add<int> ("bar", 3932)

Then, in application code, you just retrieve values using
    string foo = (string) ManosConfig.Get ("foo")
or the strongly-typed version
    ManosConfig.Get<int> ("bar")

You can store anything you want in the key/value pairs - i implemented it as a `Dictionary<string,object>` so it is flexible enough for people.

I modified the Shorty example to include a sample manos.config and changed one of the routes in the code to illustrate the typical usage scenario of the ManosConfig class.

So, tell me what you think, and if you think this is the right way, I'll give it some spit and polish and add serious error handling, use the logger, and etc.
