### PR TITLE
.NET 3.5 profile

### DIFF
--- a/src/Manos/Manos.Http/HttpFormDataHandler.cs
+++ b/src/Manos/Manos.Http/HttpFormDataHandler.cs
@@ -95,8 +95,8 @@ namespace Manos.Http {
 			entity.PostData.Set (HttpUtility.UrlDecode (key_buffer.ToString (), e),
 					HttpUtility.UrlDecode (value_buffer.ToString (), e));
 
-			key_buffer.Clear ();
-			value_buffer.Clear ();
+			key_buffer.Length = 0;
+			value_buffer.Length = 0;
 		}
 	}
 }

--- a/src/Manos/Manos.Routing/RouteHandler.cs
+++ b/src/Manos/Manos.Routing/RouteHandler.cs
@@ -39,7 +39,7 @@ namespace Manos.Routing {
 
 	public class RouteHandler : IEnumerable<RouteHandler> {
 
-		private ObservableCollection<string> patterns;
+		private C5.IList<string> patterns;
 		private List<HttpMethod> methods;
 
 		private IMatchOperation [] match_ops;
@@ -49,7 +49,7 @@ namespace Manos.Routing {
 			SetupChildrenCollection ();
 		}
 
-		void HandleChildrenCollectionChanged (object sender, NotifyCollectionChangedEventArgs e)
+		void HandleChildrenCollectionChanged (object sender, EventArgs e)
 		{
 			if (Target != null)
 				throw new InvalidOperationException ("Can not add Children to a RouteHandler that has a Target set.");	
@@ -87,9 +87,12 @@ namespace Manos.Routing {
 			
 		private void SetupChildrenCollection ()
 		{
-			var children = new ObservableCollection<RouteHandler> ();
+			var children = new C5.ArrayList<RouteHandler> ();
 			
-			children.CollectionChanged += HandleChildrenCollectionChanged;
+			children.ItemInserted += HandleChildrenCollectionChanged;
+			children.ItemsAdded += HandleChildrenCollectionChanged;
+			children.ItemRemovedAt += HandleChildrenCollectionChanged;
+			children.ItemsRemoved += HandleChildrenCollectionChanged;
 			Children = children;
 		}
 
@@ -107,7 +110,7 @@ namespace Manos.Routing {
 				}
 				else 
 				{
-					patterns = new ObservableCollection<string> ();
+					patterns = new C5.ArrayList<string> ();
 					//
 					// TODO: ObservableCollection (IList) isn't implemented yet.
 					//
@@ -115,10 +118,15 @@ namespace Manos.Routing {
 					{
 						patterns.Add (s);
 					}
-					patterns.CollectionChanged += delegate(object sender, NotifyCollectionChangedEventArgs e) 
+					EventHandler handler = delegate(object sender, EventArgs e) 
 					{
 						UpdateMatchOps ();
 					};
+
+					patterns.ItemInserted += new C5.ItemInsertedHandler<string> (handler);
+					patterns.ItemsAdded += new C5.ItemsAddedHandler<string> (handler);
+					patterns.ItemRemovedAt += new C5.ItemRemovedAtHandler<string> (handler);
+					patterns.ItemsRemoved += new C5.ItemsRemovedHandler<string> (handler);
 				}
 				UpdateMatchOps ();
 			}

--- a/src/Manos/Manos.csproj
+++ b/src/Manos/Manos.csproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Manos</RootNamespace>
     <AssemblyName>Manos</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,6 +40,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Posix" />
     <Reference Include="Mono.CSharp" />
+    <Reference Include="Mono.C5" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Manos\DeleteAttribute.cs" />
@@ -56,7 +57,6 @@
     <Compile Include="Manos\PutAttribute.cs" />
     <Compile Include="Manos\TraceAttribute.cs" />
     <Compile Include="Manos.Http\HState.cs" />
-    <compile Include="Manos.Http\HttpBufferedBodyHandler.cs" />
     <Compile Include="Manos.Http\HttpCallback.cs" />
     <Compile Include="Manos.Http\HttpCookie.cs" />
     <Compile Include="Manos.Http\HttpDataCallback.cs" />
@@ -163,6 +163,7 @@
     <Compile Include="Libev\Watcher.cs" />
     <Compile Include="Manos.Http.Testing\MockHttpResponse.cs" />
     <Compile Include="Manos\ManosConfig.cs" />
+    <Compile Include="Manos.Http\HttpBufferedBodyHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/manostool/manostool.csproj
+++ b/src/manostool/manostool.csproj
@@ -9,7 +9,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>manostool</RootNamespace>
     <AssemblyName>manostool</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Replaced ObservableCollection with C5 lists. Changed projects to target 3.5 instead of 4.0.

Unrelated change:
HttpBufferedBodyHandler.cs had to be removed and readded for the patched Manos project to build.
