### PR TITLE
Fixed default StaticContentModule to work

### DIFF
--- a/data/layouts/default/StaticContentModule.cs
+++ b/data/layouts/default/StaticContentModule.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 
 using Manos;
-
+using Manos.Routing;
 
 //
 //  This the default StaticContentModule that comes with all Manos apps
@@ -22,7 +22,7 @@ namespace $APPNAME {
 
 		public StaticContentModule ()
 		{
-			Get (".*", Content);
+			Get (".*", MatchType.Regex, Content);
 
 		}
 
@@ -43,12 +43,11 @@ namespace $APPNAME {
 		}
 
 		
-		private bool ValidFile (string path)
+		private static bool ValidFile (string path)
 		{
 			try {
 				string full = Path.GetFullPath (path);
-				if (full.StartsWith (basedir))
-					return File.Exists (full);
+				return File.Exists (full);
 			} catch {
 				return false;
 			}


### PR DESCRIPTION
After trying a test app, I found that the StaticContentModule built in didn't work. The first fix was to make ValidFile Static so that Content would actually use it. Then, I had to configure the Get to use Regex, which it seemed not to (before, it would respond to /Content/.\* instead of using it as a Regex). Finally, I changed ValidFile to not check basepath, which seems to not exist.
