### PR TITLE
Content type is already extracted, we do not need to substring.

### DIFF
--- a/src/Manos/Manos.Http/HttpMultiPartFormDataHandler.cs
+++ b/src/Manos/Manos.Http/HttpMultiPartFormDataHandler.cs
@@ -295,7 +295,7 @@ namespace Manos.Http {
 
 		public void ParseContentType (string str)
 		{
-			content_type = str.Substring ("Content-Type:".Length).Trim ();
+			content_type = str.Trim ();
 		}
 
 		public static string GetContentDispositionAttribute (string l, string name)


### PR DESCRIPTION
It could also cause parser crash if content type was short enough, for instance image/png.
