### PR TITLE
Fix windows build by assigning closed-over variables so delegates can access them

### DIFF
--- a/src/Manos/Manos.Http/HttpEntity.cs
+++ b/src/Manos/Manos.Http/HttpEntity.cs
@@ -516,7 +516,7 @@ namespace Manos.Http {
 
 		public void Complete (Action callback)
 		{
-			IAsyncWatcher completeWatcher;
+			IAsyncWatcher completeWatcher = null;
 			completeWatcher = Context.CreateAsyncWatcher (delegate {
 				completeWatcher.Dispose ();
 				callback ();

--- a/src/Manos/Manos.Http/HttpTransaction.cs
+++ b/src/Manos/Manos.Http/HttpTransaction.cs
@@ -171,7 +171,7 @@ namespace Manos.Http
 		
 		IEnumerable<ByteBuffer> ResponseFinishedCallback ()
 		{
-			IBaseWatcher handler;
+			IBaseWatcher handler = null;
 			handler = Server.Context.CreateIdleWatcher (delegate {
 				handler.Dispose ();
 				responseFinished = true;

--- a/src/Manos/Manos/AppHost.cs
+++ b/src/Manos/Manos/AppHost.cs
@@ -200,7 +200,7 @@ namespace Manos
 		{
 			Timeout t = new Timeout (begin, timespan, repeat, data, callback);
 			
-			ITimerWatcher timer;
+			ITimerWatcher timer = null;
 			timer = context.CreateTimerWatcher (begin, timespan, delegate {
 				t.Run (app);
 				if (!t.ShouldContinueToRepeat ()) {


### PR DESCRIPTION
This is a very simple fix for the windows build that simply assigns the variables to be closed over to null first, instead of a simple declaration, so the compiler won't complain about the delegate accessing an unassigned local variable.

Alex
