### PR TITLE
Windows environment and manostool docs improvements

### DIFF
--- a/src/manostool/Environment.cs
+++ b/src/manostool/Environment.cs
@@ -46,9 +46,9 @@ namespace Manos.Tool
 				|| System.Environment.OSVersion.Platform == PlatformID.Win32S
 				|| System.Environment.OSVersion.Platform == PlatformID.Win32Windows
 				|| System.Environment.OSVersion.Platform == PlatformID.WinCE) {
-				ManosDirectory = Path.GetDirectoryName(Path.GetDirectoryName(exe_path));
-                DataDirectory = Path.Combine(ManosDirectory, "..");
-                DocsDirectory = Path.Combine(ManosDirectory, "docs");
+				ManosDirectory = Path.GetDirectoryName(exe_path);
+				DataDirectory = ManosDirectory;
+				DocsDirectory = Path.Combine(ManosDirectory, "docs");
 			} else {
 				ManosDirectory = Path.GetDirectoryName (exe_path);
 				string lib_dir = Path.GetDirectoryName (ManosDirectory);


### PR DESCRIPTION
This updates the windows Environment so the directories work how the docs advertise, with all binaries in the prefix folder, docs in a "docs" subfolder, and layouts in a "layouts" subfolder. This should match the documentation now.

This also gets the docs feature in manostool working by having the tutorials be mapped by name to the correct file (like manuals are) and using the right routing rules. You'll notice that the links now show up just like the manual links, with the full name in the URL. I thought this was a cleaner way to do it, versus prepending the correct path before retrieving the MD file. Let me know your thoughts if these improvements don't strike you as such, I'm glad to work with whatever your vision is.
