### PR TITLE
Fix windows build process, manostool improvements

### DIFF
--- a/src/Manos/Manos.csproj
+++ b/src/Manos/Manos.csproj
@@ -38,9 +38,15 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Mono.Posix" />
-    <Reference Include="Mono.CSharp" />
-    <Reference Include="Mono.C5" />
+    <Reference Include="Mono.Posix">
+      <HintPath>..\..\libs\Mono.Posix.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.CSharp">
+      <HintPath>..\..\libs\Mono.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.C5">
+      <HintPath>..\..\libs\Mono.C5.dll</HintPath>
+    </Reference>
     <Reference Include="Nini, Version=1.1.0.0, Culture=neutral, PublicKeyToken=c9892194e1b9ec1b">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\libs\Nini.dll</HintPath>

--- a/src/manostool/Driver.cs
+++ b/src/manostool/Driver.cs
@@ -39,6 +39,7 @@ namespace Manos.Tool
 		public static readonly string COMPILED_TEMPLATES_ASSEMBLY = "CompiledTemplates.dll";
 		public static readonly string TEMPLATES_DIRECTORY = "Templates";
 		public static readonly string DEPLOYMENT_DIRECTORY = "Deployment";
+		public static readonly string MANOS_TOOLNAME = "manostool";
 		
 		private static Environment Environment = new Environment ();
 
@@ -65,7 +66,7 @@ namespace Manos.Tool
 			try {
 				extra = p.Parse(args);
 			} catch (OptionException){
-				Console.WriteLine ("Try `manos --help' for more information.");
+				Console.WriteLine (string.Format ("Try `{0} --help' for more information.", MANOS_TOOLNAME));
 				return 1;
 			}
 			
@@ -115,7 +116,7 @@ namespace Manos.Tool
 			try {
 				extra = p.Parse(args);
 			} catch (OptionException){
-				Console.WriteLine ("Try `manos --help' for more information.");
+				Console.WriteLine (string.Format ("Try `{0} --help' for more information.", MANOS_TOOLNAME));
 				return null;
 			}
 			
@@ -128,11 +129,16 @@ namespace Manos.Tool
 		private static int Init (IList<string> args)
 		{
 			if (args.Count < 1) {
-				Console.WriteLine ("manos --init <AppName>");
+				Console.WriteLine (string.Format ("{0} --init <AppName>", MANOS_TOOLNAME));
 				Console.WriteLine ("This will initialize a new application with the supplied name.");
 			}
 				
 			Driver d = new Driver ();
+
+			if (args.Count <= 0) {
+				Console.WriteLine ("Error: Unable to init without an AppName.");
+				return 1;
+			}
 			
 			try {
 				Console.WriteLine ("initing: {0}", args [0]);
@@ -276,18 +282,24 @@ namespace Manos.Tool
 
 		private static int ShowEnvironment (IList<string> args)
 		{
-			Console.WriteLine ("libdir: '{0}'", Environment.LibDirectory);
-			Console.WriteLine ("manosdir: '{0}'", Environment.ManosDirectory);
-			Console.WriteLine ("workingdir: '{0}'", Environment.WorkingDirectory);
-			Console.WriteLine ("datadir: '{0}'", Environment.DataDirectory);
-			Console.WriteLine ("datadir: '{0}'", Environment.DocsDirectory);
+			if (Environment.IsWindows) {
+				Console.WriteLine ("manosdir: '{0}'", Environment.ManosDirectory);
+				Console.WriteLine ("datadir: '{0}'", Environment.DataDirectory);
+				Console.WriteLine ("docsdir: '{0}'", Environment.DocsDirectory);
+			} else {
+				Console.WriteLine ("libdir: '{0}'", Environment.LibDirectory);
+				Console.WriteLine ("manosdir: '{0}'", Environment.ManosDirectory);
+				Console.WriteLine ("workingdir: '{0}'", Environment.WorkingDirectory);
+				Console.WriteLine ("datadir: '{0}'", Environment.DataDirectory);
+				Console.WriteLine ("docsdir: '{0}'", Environment.DocsDirectory);
+			}
 
 			return 1;
 		}
 
 		private static void ShowHelp (OptionSet os)
 		{
-			Console.WriteLine ("manos usage is: manos [command] [options]");
+			Console.WriteLine (string.Format ("{0} usage is: {0} [command] [options]", MANOS_TOOLNAME));
 			Console.WriteLine ();
 			os.WriteOptionDescriptions (Console.Out);
 		}

--- a/src/manostool/Environment.cs
+++ b/src/manostool/Environment.cs
@@ -39,6 +39,7 @@ namespace Manos.Tool
 			LibDirectory = "lib";
 			TemplatesDirectory = "Templates";
 			WorkingDirectory = Directory.GetCurrentDirectory ();
+			IsWindows = false;
 			
 			string exe_path = new Uri (typeof (Driver).Assembly.GetName ().CodeBase).LocalPath;
 
@@ -46,6 +47,7 @@ namespace Manos.Tool
 				|| System.Environment.OSVersion.Platform == PlatformID.Win32S
 				|| System.Environment.OSVersion.Platform == PlatformID.Win32Windows
 				|| System.Environment.OSVersion.Platform == PlatformID.WinCE) {
+				IsWindows = true;
 				ManosDirectory = Path.GetDirectoryName(exe_path);
 				DataDirectory = ManosDirectory;
 				DocsDirectory = Path.Combine(ManosDirectory, "docs");
@@ -87,6 +89,11 @@ namespace Manos.Tool
 		public string DocsDirectory {
 			get;
 			set;
+		}
+
+		public bool IsWindows {
+			get;
+			private set;
 		}
 	}
 }


### PR DESCRIPTION
These commits modify the .csproj file for the Manos project to specify that the Mono.\* dlls are located in the same lib directory as the Nini.dll file, so windows users can just grab those dlls and place them in the lib directory to build. This won't change the mono build process since those assemblies are already in the GAC.

I didn't bundle the dlls themselves in these commits since they are quite large, and we probably want users to get them for themselves, although the Mono.CSharp assembly is a little in-limbo with API changes, so bundling 2.8's version might be wise.

This also changes Environment to add an IsWindows property, so we can switch the manostool --se ouput for different platforms, since the environments differ on windows and *nix. This also adds an error if --init is called with no argument, and moves the name of the tool (manostool) to a static field so we don't have to write the tool name over and over, and it can be easily changed.
