### PR TITLE
Remove dependency from Manos.Http on Manos's Apphost.

### DIFF
--- a/src/Manos/Manos.Http/HttpRequest.cs
+++ b/src/Manos/Manos.Http/HttpRequest.cs
@@ -193,7 +193,7 @@ namespace Manos.Http {
 		public void Execute ()
 		{
 			var remote = new IPEndPoint(IPAddress.Parse (RemoteAddress), RemotePort);
-			Socket = AppHost.Context.CreateTcpSocket (remote.AddressFamily);
+			Socket = this.Context.CreateTcpSocket (remote.AddressFamily);
 			Socket.Connect (remote, delegate {
 				Stream = new HttpStream (this, Socket.GetSocketStream ());
 				Stream.Chunked = false;


### PR DESCRIPTION
Remove dependency from Manos.Http on Manos's Apphost. We have the context here, so just use it directly. This is needed for those people using the Manos.Http server without using the Manos framework stuff.
