### PR TITLE
Add INotifier.

### DIFF
--- a/src/Manos.IO/Libev/Pipe.cs
+++ b/src/Manos.IO/Libev/Pipe.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Runtime.InteropServices;
+using Mono.Unix;
+using Mono.Unix.Native;
+
+namespace Libev
+{
+	public class Pipe
+	{
+		int[] pipe = new int[2];
+
+		public Pipe()
+		{
+			Syscall.pipe(pipe);
+		}
+
+		public IntPtr Out {
+			get {
+				return new IntPtr(pipe[0]);
+			}
+		}
+
+		public IntPtr In {
+			get {
+				return new IntPtr(pipe[1]);
+			}
+		}
+
+		public void Write(IntPtr buf, ulong count)
+		{
+			Syscall.write(pipe[1], buf, count);
+		}
+
+		public void Write(byte[] buffer, int start, int count)
+		{
+			if (start + count >= buffer.Length) {
+				throw new ArgumentException();
+			}
+			var ptr = Marshal.AllocHGlobal(count);
+			Marshal.Copy(buffer, start, ptr, count);
+			Write(ptr, (ulong)count);
+			Marshal.FreeHGlobal(ptr);
+		}
+
+		public void Read(IntPtr buf, ulong count)
+		{
+			Syscall.read(pipe[0], buf, count);
+		}
+
+		public void Close()
+		{
+			for (int i = 0; i < pipe.Length; i++) {
+				Syscall.close(pipe[i]);
+			}
+		}
+	}
+}
+

--- a/src/Manos.IO/Manos.IO.Libev/Context.cs
+++ b/src/Manos.IO/Manos.IO.Libev/Context.cs
@@ -138,6 +138,11 @@ namespace Manos.IO.Libev
 		{
 			return new UdpSocket (this, family);
 		}
+
+		public override INotifier CreateNotifier (Action callback)
+		{
+			return new Notifier (this, callback);
+		}
 	}
 }
 

--- a/src/Manos.IO/Manos.IO.Libev/Notifier.cs
+++ b/src/Manos.IO/Manos.IO.Libev/Notifier.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Runtime.InteropServices;
+using Libev;
+
+namespace Manos.IO.Libev
+{
+	class Notifier : INotifier, IBaseWatcher, IDisposable
+	{
+		Pipe pipe;
+		IOWatcher iowatcher;
+		IntPtr data;
+
+		public Notifier (Context context, Action callback)
+		{
+			data = Marshal.AllocHGlobal(1);
+
+			pipe = new Pipe();
+			iowatcher = new IOWatcher(pipe.Out, EventTypes.Read, context.Loop, (iow, ev) => {
+				pipe.Read (data, 1);
+				if (callback != null) {
+					callback();
+				}
+			});
+		}
+
+		~Notifier ()
+		{
+			Dispose (false);
+		}
+
+		public void Notify ()
+		{
+			pipe.Write (data, 1);
+		}
+
+		public void Start ()
+		{
+			iowatcher.Start();
+		}
+
+		public void Stop ()
+		{
+			iowatcher.Stop ();
+		}
+
+		public bool IsRunning {
+			get {
+				return iowatcher.IsRunning;
+			}
+		}
+
+		public void Dispose ()
+		{
+			Dispose (true);
+			GC.SuppressFinalize (this);
+		}
+
+		protected void Dispose (bool disposing)
+		{
+			if (data != IntPtr.Zero) {
+				Marshal.FreeHGlobal(data);
+				data = IntPtr.Zero;
+			}
+		}
+	}
+}
+

--- a/src/Manos.IO/Manos.IO.Managed/Context.cs
+++ b/src/Manos.IO/Manos.IO.Managed/Context.cs
@@ -225,6 +225,11 @@ namespace Manos.IO.Managed
 		{
 			return new UdpSocket (this, family);
 		}
+
+		public override INotifier CreateNotifier (Action callback)
+		{
+			return new Notifier (this, callback);
+		}
 	}
 }
 

--- a/src/Manos.IO/Manos.IO.Managed/Notifier.cs
+++ b/src/Manos.IO/Manos.IO.Managed/Notifier.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace Manos.IO.Managed
+{
+	class Notifier : INotifier
+	{
+		Action callback;
+		Context context;
+		int count = 0;
+		object syncRoot = new object();
+
+		public Notifier (Context context, Action callback)
+		{
+			this.callback = callback;
+			this.context = context;
+		}
+
+		public void Notify ()
+		{
+			lock (syncRoot) {
+				if (IsRunning) {
+					context.Enqueue (callback);
+				} else {
+					count++;
+				}
+			}
+		}
+
+		public void Start ()
+		{
+			lock (syncRoot) {
+				if (!IsRunning) {
+					while (count > 0) {
+						context.Enqueue (callback);
+						count--;
+					}
+					IsRunning = true;
+				}
+			}
+		}
+
+		public void Stop ()
+		{
+			lock (syncRoot) {
+				if (IsRunning) {
+					IsRunning = false;
+				}
+			}
+		}
+
+		public bool IsRunning {
+			get;
+			protected set;
+		}
+
+		public void Dispose ()
+		{
+		}
+	}
+}
+

--- a/src/Manos.IO/Manos.IO.csproj
+++ b/src/Manos.IO/Manos.IO.csproj
@@ -116,6 +116,10 @@
     <Compile Include="Manos.IO\Errors.cs" />
     <Compile Include="Manos.IO\IOException.cs" />
     <Compile Include="Manos.IO\OpenMode.cs" />
+    <Compile Include="Manos.IO\INotifier.cs" />
+    <Compile Include="Libev\Pipe.cs" />
+    <Compile Include="Manos.IO.Libev\Notifier.cs" />
+    <Compile Include="Manos.IO.Managed\Notifier.cs" />
   </ItemGroup>
   <Target Name="ListSources">
     <Message Text="@(Compile)" Importance="High" />

--- a/src/Manos.IO/Manos.IO/Context.cs
+++ b/src/Manos.IO/Manos.IO/Context.cs
@@ -276,6 +276,14 @@ namespace Manos.IO
 		/// Address family the socket belongs to.
 		/// </param>
 		public abstract IUdpSocket CreateUdpSocket (AddressFamily family);
+
+		/// <summary>
+		/// Creates a new notifier.
+		/// </summary>
+		/// <returns>
+		/// The notifier.
+		/// </returns>
+		public abstract INotifier CreateNotifier (Action callback);
 	}
 }
 

--- a/src/Manos.IO/Manos.IO/INotifier.cs
+++ b/src/Manos.IO/Manos.IO/INotifier.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Manos.IO
+{
+	public interface INotifier : IBaseWatcher
+	{
+		void Notify();
+	}
+}
+


### PR DESCRIPTION
The Notifier is an awesome tool to write thread safe communication classes.
Imagine you have two loops in different threads and you want communicate between them.

For example, something as easy as this could be implemented in order to provide convenient communication between loops in different threads:

``` csharp
class Notifier<T>
{
    Queue<T> queue;
    Notifier notifier;
    Notifier (Context context, Action<T> callback)
    {
        context.CreateNotifier (context, () => {
            T item = null;
            lock (queue) {
                item = queue.Dequeue ();
            }
            if (callback != null) {
                callback (item);
            }
        }).Start();
    }

    public void Notify (T data)
    {
        lock (queue) {
            queue.Enqueue(data);
        }
        notifier.Notify ();
    }
}
```

Still some locks there, but they are pretty much minimal and are needed if you want to share state between 2 threads.
